### PR TITLE
Add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,20 @@
+{
+  "name": "BindTable",
+  "main": "bindtable.js",
+  "version": "0.0.1",
+  "homepage": "https://github.com/knowthen/BindTable",
+  "authors": [
+    "thejsj <james@knowthen.com>"
+  ],
+  "license": "MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ],
+  "dependencies": {
+    "angular": "~1.3.15"
+  }
+}

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "BindTable",
   "main": "bindtable.js",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "homepage": "https://github.com/knowthen/BindTable",
   "authors": [
     "thejsj <james@knowthen.com>"
@@ -15,6 +15,6 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "~1.3.15"
+    "angular": "^1.3.13"
   }
 }


### PR DESCRIPTION
I don't know if there's a reason why you haven't added this to Bower, but I wanted to `bower install` this and couldn't. 

I added the `bower.json`, which means that you would only need to tag a release with git and then do `bower register`.

Let me know if there's a reason you haven't done this.
